### PR TITLE
The acronym package uses the wrong front for thesis using times or couri...

### DIFF
--- a/npsreport.cls
+++ b/npsreport.cls
@@ -388,6 +388,16 @@
 % Support for the acronym package
 \ifnpsacronym
   \usepackage[printonlyused]{acronym}
+  \iffonttimesset
+    % fixes the acronym list to be in times font as well.
+    % it originally is in arial font based on an earlier
+    % define of bflabel.
+    \renewcommand{\bflabel}[1]{{\textbf{#1}\hfill}}
+  \fi
+  \iffontcourierset
+    % this is the fix for the courier font.
+    \renewcommand{\bflabel}[1]{{\textbf{\texttt{#1}}\hfill}}
+  \fi
 \fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
...er fonts.  This corrects the macros to use the appropriate front from the documentclass option.
