### PR TITLE
Add @law construct and bump bst version

### DIFF
--- a/nps_thesis.bst
+++ b/nps_thesis.bst
@@ -7,8 +7,8 @@
 %% Copyright (c) 2014-2016 Mark Gondree
 %% https://github.com/nps-tug/nps-thesis-template
 
-FUNCTION{bst.file.version} { "2.0" }
-FUNCTION{bst.file.date} { "2016/05/05" }
+FUNCTION{bst.file.version} { "2.1" }
+FUNCTION{bst.file.date} { "2018/08/27" }
 FUNCTION{bst.file.name} { "nps_thesis.bst" }
 
 %%
@@ -2229,6 +2229,20 @@ FUNCTION {inproceedings}
   format.paper output
   format.pages output
   format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {law}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.classification output
+  format.book.title.edition "title" output.warn
+  std.status.using.period
+  format.howpublished "howpublished" bibinfo.warn output
+  format.date "year" output.warn
   format.url output
   fin.entry
   if.url.std.interword.spacing


### PR DESCRIPTION
Hello!  I've added a "law" type that can be used to produce the Public Law entry in the IEEE citation style linked from http://libguides.nps.edu/citation/ieee#legal-public-law

This commit was written within the scope of my federal employment as a U.S. Government employee and thus is ineligible for copyright protection in the U.S.; this is generally understood to mean that these portions of the Project are placed in the public domain.

In countries where copyright protection is available (which does not include the U.S.), this contribution is released under the LPPL as defined in the modified file.